### PR TITLE
80 project information summary on map info card tab

### DIFF
--- a/Assets/Dataskop/Scenes/World.unity
+++ b/Assets/Dataskop/Scenes/World.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44402185, g: 0.49316472, b: 0.57223153, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -506,6 +506,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 614059771}
+        m_TargetAssemblyTypeName: Dataskop.UI.InfoCardProjectSummary, Dataskop
+        m_MethodName: OnProjectLoaded
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   loadingIndicator: {fileID: 1499203927}
   fetchAmount: 2000
   fetchInterval: 15000
@@ -786,6 +798,7 @@ GameObject:
   - component: {fileID: 614059765}
   - component: {fileID: 614059767}
   - component: {fileID: 614059769}
+  - component: {fileID: 614059771}
   - component: {fileID: 614059770}
   m_Layer: 5
   m_Name: InfoCardCanvas
@@ -1038,6 +1051,19 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
   section: 0
+--- !u!114 &614059771
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 614059760}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 003872e1cc189cc419d824ba8c9d86ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  infoCardDoc: {fileID: 614059761}
 --- !u!1 &620153294
 GameObject:
   m_ObjectHideFlags: 0
@@ -3695,7 +3721,19 @@ MonoBehaviour:
         m_CallState: 2
   nearbyDevicesUpdated:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 614059771}
+        m_TargetAssemblyTypeName: Dataskop.UI.InfoCardProjectSummary, Dataskop
+        m_MethodName: OnNearbyDevicesUpdated
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   dataManager: {fileID: 284049158}
   inputHandler: {fileID: 1561813931}
   map: {fileID: 7949688664006150128}

--- a/Assets/Dataskop/Scripts/Core/UI/InformationCard/InfoCardProjectSummary.cs
+++ b/Assets/Dataskop/Scripts/Core/UI/InformationCard/InfoCardProjectSummary.cs
@@ -31,7 +31,7 @@ namespace Dataskop.UI {
 
 		public void OnProjectLoaded(Project project) {
 			ProjectName.text = project.Information.Name;
-			ProjectDescription.text = project.Information.Info;
+			ProjectDescription.text = project.Information.Description;
 			ProjectTotalDevices.text = project.Devices.Count.ToString("00");
 			
 			string[] array = new string[project.Properties.Attributes.Count];

--- a/Assets/Dataskop/Scripts/Core/UI/InformationCard/InfoCardProjectSummary.cs
+++ b/Assets/Dataskop/Scripts/Core/UI/InformationCard/InfoCardProjectSummary.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Dataskop.Data;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Dataskop.UI {
+
+	public class InfoCardProjectSummary : MonoBehaviour {
+
+		[SerializeField] private UIDocument infoCardDoc;
+		
+		private VisualElement ProjectSummaryContainer { get; set; }
+		
+		private Label ProjectName { get; set; }
+		private Label ProjectDescription { get; set; }
+		private Label ProjectTotalDevices { get; set; }
+		private Label ProjectDevicesNearby { get; set; }
+		private Label ProjectMeasurements { get; set; }
+
+		private void Awake() {
+			ProjectSummaryContainer = infoCardDoc.rootVisualElement.Q<VisualElement>("ProjectData");
+			ProjectName = ProjectSummaryContainer.Q<Label>("NameValue");
+			ProjectDescription = ProjectSummaryContainer.Q<Label>("DescriptionValue");
+			ProjectTotalDevices = ProjectSummaryContainer.Q<Label>("TotalDevicesValue");
+			ProjectDevicesNearby = ProjectSummaryContainer.Q<Label>("DevicesNearbyValue");
+			ProjectMeasurements = ProjectSummaryContainer.Q<Label>("MeasurementsValue");
+		}
+
+		public void OnProjectLoaded(Project project) {
+			ProjectName.text = project.Information.Name;
+			ProjectDescription.text = project.Information.Info;
+			ProjectTotalDevices.text = project.Devices.Count.ToString("00");
+			
+			string[] array = new string[project.Properties.Attributes.Count];
+			for (int i = 0; i < array.Length; i++) {
+				array[i] = project.Properties.Attributes.ToArray()[i].Label;
+			}
+
+			ProjectMeasurements.text = string.Join(", ", array);
+		}
+
+		public void OnNearbyDevicesUpdated(int devicesNearbyCount) {
+			ProjectDevicesNearby.text = devicesNearbyCount.ToString("00");
+		}
+
+	}
+
+}

--- a/Assets/Dataskop/Scripts/Core/UI/InformationCard/InfoCardProjectSummary.cs
+++ b/Assets/Dataskop/Scripts/Core/UI/InformationCard/InfoCardProjectSummary.cs
@@ -16,6 +16,7 @@ namespace Dataskop.UI {
 		
 		private Label ProjectName { get; set; }
 		private Label ProjectDescription { get; set; }
+		private Label ProjectCreationDate { get; set; }
 		private Label ProjectTotalDevices { get; set; }
 		private Label ProjectDevicesNearby { get; set; }
 		private Label ProjectMeasurements { get; set; }
@@ -24,6 +25,7 @@ namespace Dataskop.UI {
 			ProjectSummaryContainer = infoCardDoc.rootVisualElement.Q<VisualElement>("ProjectData");
 			ProjectName = ProjectSummaryContainer.Q<Label>("NameValue");
 			ProjectDescription = ProjectSummaryContainer.Q<Label>("DescriptionValue");
+			ProjectCreationDate = ProjectSummaryContainer.Q<Label>("CreationDateValue");
 			ProjectTotalDevices = ProjectSummaryContainer.Q<Label>("TotalDevicesValue");
 			ProjectDevicesNearby = ProjectSummaryContainer.Q<Label>("DevicesNearbyValue");
 			ProjectMeasurements = ProjectSummaryContainer.Q<Label>("MeasurementsValue");
@@ -32,6 +34,7 @@ namespace Dataskop.UI {
 		public void OnProjectLoaded(Project project) {
 			ProjectName.text = project.Information.Name;
 			ProjectDescription.text = project.Information.Description;
+			ProjectCreationDate.text = project.Information.CreatedDate.ToShortDateString();
 			ProjectTotalDevices.text = project.Devices.Count.ToString("00");
 			
 			string[] array = new string[project.Properties.Attributes.Count];

--- a/Assets/Dataskop/Scripts/Core/UI/InformationCard/InfoCardProjectSummary.cs.meta
+++ b/Assets/Dataskop/Scripts/Core/UI/InformationCard/InfoCardProjectSummary.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 003872e1cc189cc419d824ba8c9d86ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Dataskop/UIComponents/InfoCard/InfoCard.uxml
+++ b/Assets/Dataskop/UIComponents/InfoCard/InfoCard.uxml
@@ -81,7 +81,7 @@
             <ui:VisualElement name="ProjectOverview" picking-mode="Ignore" class="meta-info-container" style="flex-direction: row; justify-content: space-between; margin-top: 45px; margin-bottom: 20px; width: 98%;">
                 <ui:Label text="Project Overview" display-tooltip-when-elided="true" name="OverviewHeadline" class="meta-info-text" style="-unity-font-style: bold; font-size: 32px; color: rgb(60, 60, 60); -unity-font: url(&quot;project://database/Assets/Dataskop/Fonts/OpenSans-Semibold.ttf?fileID=12800000&amp;guid=218956a5c2a6e42d6a60afccf80b002b&amp;type=3#OpenSans-Semibold&quot;); -unity-font-definition: initial; margin-left: 0;" />
             </ui:VisualElement>
-            <ui:VisualElement name="ProjectData" class="data-display-container" style="flex-grow: 0; flex-direction: column; margin-right: 0; margin-left: 0; width: 98%; height: auto; flex-shrink: 1; flex-basis: auto; padding-right: 15px; padding-left: 15px;">
+            <ui:ScrollView scroll-deceleration-rate="0,135" elasticity="0,1" name="ProjectData" class="data-display-container project-summary-data-container" style="margin-bottom: 50px;">
                 <ui:VisualElement class="data-row" style="background-color: rgba(255, 255, 255, 0);">
                     <ui:Label text="Name:" display-tooltip-when-elided="true" name="Name" class="data-text data-title" />
                     <ui:Label text="-" display-tooltip-when-elided="true" name="NameValue" class="data-text data-value" />
@@ -102,7 +102,7 @@
                     <ui:Label text="Available Measurements:" display-tooltip-when-elided="true" name="Measurements" class="data-text data-title" />
                     <ui:Label text="-" display-tooltip-when-elided="true" name="MeasurementsValue" enable-rich-text="true" parse-escape-sequences="false" class="data-text data-value data-value-long-text" />
                 </ui:VisualElement>
-            </ui:VisualElement>
+            </ui:ScrollView>
         </ui:VisualElement>
     </ui:VisualElement>
 </ui:UXML>

--- a/Assets/Dataskop/UIComponents/InfoCard/InfoCard.uxml
+++ b/Assets/Dataskop/UIComponents/InfoCard/InfoCard.uxml
@@ -94,6 +94,10 @@
                     <ui:Label text="Date Created:" display-tooltip-when-elided="true" name="CreationDate" class="data-text data-title" />
                     <ui:Label text="-" display-tooltip-when-elided="true" name="CreationDateValue" class="data-text data-value" />
                 </ui:VisualElement>
+                <ui:VisualElement class="data-row data-long-text">
+                    <ui:Label text="Available Measurements:" display-tooltip-when-elided="true" name="Measurements" class="data-text data-title" />
+                    <ui:Label text="-" display-tooltip-when-elided="true" name="MeasurementsValue" enable-rich-text="true" parse-escape-sequences="false" class="data-text data-value data-value-long-text" />
+                </ui:VisualElement>
                 <ui:VisualElement class="data-row" style="background-color: rgba(255, 255, 255, 0);">
                     <ui:Label text="Total Devices in Project:" display-tooltip-when-elided="true" name="TotalDevices" class="data-text data-title" />
                     <ui:Label text="-" display-tooltip-when-elided="true" name="TotalDevicesValue" class="data-text data-value" />
@@ -101,10 +105,6 @@
                 <ui:VisualElement class="data-row" style="background-color: rgba(255, 255, 255, 0);">
                     <ui:Label text="Devices near you:" display-tooltip-when-elided="true" name="DevicesNearby" class="data-text data-title" />
                     <ui:Label text="-" display-tooltip-when-elided="true" name="DevicesNearbyValue" class="data-text data-value" />
-                </ui:VisualElement>
-                <ui:VisualElement class="data-row data-long-text">
-                    <ui:Label text="Available Measurements:" display-tooltip-when-elided="true" name="Measurements" class="data-text data-title" />
-                    <ui:Label text="-" display-tooltip-when-elided="true" name="MeasurementsValue" enable-rich-text="true" parse-escape-sequences="false" class="data-text data-value data-value-long-text" />
                 </ui:VisualElement>
             </ui:ScrollView>
         </ui:VisualElement>

--- a/Assets/Dataskop/UIComponents/InfoCard/InfoCard.uxml
+++ b/Assets/Dataskop/UIComponents/InfoCard/InfoCard.uxml
@@ -73,10 +73,35 @@
         <ui:VisualElement name="MapContainer" class="data-container" style="display: flex;">
             <ui:VisualElement name="Map" class="map" />
             <ui:Button display-tooltip-when-elided="true" name="ZoomInButton" text="+" class="app-button" style="position: absolute; top: 70px; left: auto; right: 70px; font-size: 64px; -unity-text-align: middle-center; margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px; -unity-font: url(&quot;project://database/Assets/Dataskop/Fonts/OpenSans-Bold.ttf?fileID=12800000&amp;guid=7dfc2e1472ac84e1bb749a8a9f934483&amp;type=3#OpenSans-Bold&quot;); padding-left: 10px; padding-right: 10px; padding-top: 10px; padding-bottom: 17px; justify-content: center; color: rgb(37, 89, 176); -unity-font-style: bold;" />
-            <ui:Button display-tooltip-when-elided="true" name="ZoomOutButton" text="-" class="app-button" style="position: absolute; top: 170px; left: auto; right: 70px; margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px; padding-left: 10px; padding-right: 10px; padding-top: 10px; padding-bottom: 17px; font-size: 72px; -unity-font: url(&quot;project://database/Assets/Dataskop/Fonts/OpenSans-Bold.ttf?fileID=12800000&amp;guid=7dfc2e1472ac84e1bb749a8a9f934483&amp;type=3#OpenSans-Bold&quot;); color: rgb(37, 89, 176); -unity-font-style: bold;" />
-            <ui:VisualElement name="LocatorContainer" class="locator-container data-display-container" style="flex-direction: row; justify-content: space-between;">
+            <ui:VisualElement name="LocatorContainer" class="locator-container data-display-container" style="flex-direction: row; justify-content: space-between; padding-top: 15px; padding-right: 15px; padding-bottom: 15px; padding-left: 15px; margin-right: 0; margin-left: 0; width: 98%;">
                 <ui:Label text="Location" display-tooltip-when-elided="true" name="Location" class="locator-text" style="-unity-text-align: middle-left; -unity-font: url(&quot;project://database/Assets/Dataskop/Fonts/OpenSans-Semibold.ttf?fileID=12800000&amp;guid=218956a5c2a6e42d6a60afccf80b002b&amp;type=3#OpenSans-Semibold&quot;);" />
                 <ui:Label text="Area" display-tooltip-when-elided="true" name="Area" class="locator-text" />
+            </ui:VisualElement>
+            <ui:Button display-tooltip-when-elided="true" name="ZoomOutButton" text="-" class="app-button" style="position: absolute; top: 170px; left: auto; right: 70px; margin-left: 4px; margin-right: 4px; margin-top: 4px; margin-bottom: 4px; padding-left: 10px; padding-right: 10px; padding-top: 10px; padding-bottom: 17px; font-size: 72px; -unity-font: url(&quot;project://database/Assets/Dataskop/Fonts/OpenSans-Bold.ttf?fileID=12800000&amp;guid=7dfc2e1472ac84e1bb749a8a9f934483&amp;type=3#OpenSans-Bold&quot;); color: rgb(37, 89, 176); -unity-font-style: bold;" />
+            <ui:VisualElement name="ProjectOverview" picking-mode="Ignore" class="meta-info-container" style="flex-direction: row; justify-content: space-between; margin-top: 45px; margin-bottom: 20px; width: 98%;">
+                <ui:Label text="Project Overview" display-tooltip-when-elided="true" name="OverviewHeadline" class="meta-info-text" style="-unity-font-style: bold; font-size: 32px; color: rgb(60, 60, 60); -unity-font: url(&quot;project://database/Assets/Dataskop/Fonts/OpenSans-Semibold.ttf?fileID=12800000&amp;guid=218956a5c2a6e42d6a60afccf80b002b&amp;type=3#OpenSans-Semibold&quot;); -unity-font-definition: initial; margin-left: 0;" />
+            </ui:VisualElement>
+            <ui:VisualElement name="ProjectData" class="data-display-container" style="flex-grow: 0; flex-direction: column; margin-right: 0; margin-left: 0; width: 98%; height: auto; flex-shrink: 1; flex-basis: auto; padding-right: 15px; padding-left: 15px;">
+                <ui:VisualElement class="data-row" style="background-color: rgba(255, 255, 255, 0);">
+                    <ui:Label text="Name:" display-tooltip-when-elided="true" name="Name" class="data-text data-title" />
+                    <ui:Label text="-" display-tooltip-when-elided="true" name="NameValue" class="data-text data-value" />
+                </ui:VisualElement>
+                <ui:VisualElement class="data-row data-long-text">
+                    <ui:Label text="Description:" display-tooltip-when-elided="true" name="Description" class="data-text data-title" />
+                    <ui:Label text="-" display-tooltip-when-elided="true" name="DescriptionValue" enable-rich-text="true" parse-escape-sequences="false" class="data-text data-value data-value-long-text" />
+                </ui:VisualElement>
+                <ui:VisualElement class="data-row" style="background-color: rgba(255, 255, 255, 0);">
+                    <ui:Label text="Total Devices:" display-tooltip-when-elided="true" name="TotalDevices" class="data-text data-title" />
+                    <ui:Label text="-" display-tooltip-when-elided="true" name="TotalDevicesValue" class="data-text data-value" />
+                </ui:VisualElement>
+                <ui:VisualElement class="data-row" style="background-color: rgba(255, 255, 255, 0);">
+                    <ui:Label text="Devices near you:" display-tooltip-when-elided="true" name="DevicesNearby" class="data-text data-title" />
+                    <ui:Label text="-" display-tooltip-when-elided="true" name="DevicesNearbyValue" class="data-text data-value" />
+                </ui:VisualElement>
+                <ui:VisualElement class="data-row data-long-text">
+                    <ui:Label text="Available Measurements:" display-tooltip-when-elided="true" name="Measurements" class="data-text data-title" />
+                    <ui:Label text="-" display-tooltip-when-elided="true" name="MeasurementsValue" enable-rich-text="true" parse-escape-sequences="false" class="data-text data-value data-value-long-text" />
+                </ui:VisualElement>
             </ui:VisualElement>
         </ui:VisualElement>
     </ui:VisualElement>

--- a/Assets/Dataskop/UIComponents/InfoCard/InfoCard.uxml
+++ b/Assets/Dataskop/UIComponents/InfoCard/InfoCard.uxml
@@ -91,7 +91,11 @@
                     <ui:Label text="-" display-tooltip-when-elided="true" name="DescriptionValue" enable-rich-text="true" parse-escape-sequences="false" class="data-text data-value data-value-long-text" />
                 </ui:VisualElement>
                 <ui:VisualElement class="data-row" style="background-color: rgba(255, 255, 255, 0);">
-                    <ui:Label text="Total Devices:" display-tooltip-when-elided="true" name="TotalDevices" class="data-text data-title" />
+                    <ui:Label text="Date Created:" display-tooltip-when-elided="true" name="CreationDate" class="data-text data-title" />
+                    <ui:Label text="-" display-tooltip-when-elided="true" name="CreationDateValue" class="data-text data-value" />
+                </ui:VisualElement>
+                <ui:VisualElement class="data-row" style="background-color: rgba(255, 255, 255, 0);">
+                    <ui:Label text="Total Devices in Project:" display-tooltip-when-elided="true" name="TotalDevices" class="data-text data-title" />
                     <ui:Label text="-" display-tooltip-when-elided="true" name="TotalDevicesValue" class="data-text data-value" />
                 </ui:VisualElement>
                 <ui:VisualElement class="data-row" style="background-color: rgba(255, 255, 255, 0);">

--- a/Assets/Dataskop/UIComponents/InfoCard/InfoCardStyles.uss
+++ b/Assets/Dataskop/UIComponents/InfoCard/InfoCardStyles.uss
@@ -303,3 +303,35 @@ VisualElement {
     -unity-font: url("project://database/Assets/Dataskop/Fonts/OpenSans-Bold.ttf?fileID=12800000&guid=7dfc2e1472ac84e1bb749a8a9f934483&type=3#OpenSans-Bold");
     -unity-font-definition: initial;
 }
+
+.project-summary-container {
+    flex-grow: 1;
+    justify-content: flex-start;
+}
+
+.data-long-text {
+    background-color: rgba(255, 255, 255, 0);
+    flex-grow: 0;
+    flex-wrap: wrap;
+    flex-direction: row;
+    height: auto;
+    align-self: auto;
+    align-items: flex-start;
+    width: auto;
+    min-width: 98%;
+    max-width: 98px;
+}
+
+.data-value-long-text {
+    flex-wrap: wrap;
+    max-width: none;
+    min-width: auto;
+    white-space: normal;
+    text-overflow: clip;
+    min-height: auto;
+    height: auto;
+    flex-grow: 1;
+    -unity-text-align: upper-left;
+    align-items: stretch;
+    width: auto;
+}

--- a/Assets/Dataskop/UIComponents/InfoCard/InfoCardStyles.uss
+++ b/Assets/Dataskop/UIComponents/InfoCard/InfoCardStyles.uss
@@ -335,3 +335,17 @@ VisualElement {
     align-items: stretch;
     width: auto;
 }
+
+.project-summary-data-container {
+    flex-grow: 0;
+    flex-direction: column;
+    margin-right: 0;
+    margin-left: 0;
+    width: 98%;
+    height: auto;
+    flex-shrink: 1;
+    flex-basis: auto;
+    padding-right: 15px;
+    padding-left: 15px;
+    min-height: 0;
+}


### PR DESCRIPTION
Added project summary to the map info card tab including:

- Project Name
- Description
- Date Created
- Available Measurements
- Total Devices
- Devices near you

Everything was added in a scroll container since Description and Available Measurements could be rather long strings, which would push the element to the bottom. This would still need to be tested on a device to make sure scrolling is smooth.