### PR TITLE
24 ability to save set options

### DIFF
--- a/Assets/Dataskop/Scenes/World.unity
+++ b/Assets/Dataskop/Scenes/World.unity
@@ -329,6 +329,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 1514474210}
+        m_TargetAssemblyTypeName: Dataskop.SettingsManager, Dataskop
+        m_MethodName: OnAmountInputChanged
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   cooldownInputChanged:
     m_PersistentCalls:
       m_Calls:
@@ -344,6 +356,24 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 1514474210}
+        m_TargetAssemblyTypeName: Dataskop.SettingsManager, Dataskop
+        m_MethodName: OnFetchIntervalInputChanged
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  validTimeRangeEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  dateFilterDisabled:
+    m_PersistentCalls:
+      m_Calls: []
   menuDocument: {fileID: 213483610}
   selectedIconColor: {r: 0.8584906, g: 0.41105816, b: 0.044544328, a: 1}
   deselectedIconColor: {r: 0.14618193, g: 0.3496184, b: 0.6886792, a: 1}
@@ -2823,6 +2853,50 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   loadingIndicatorUiDocument: {fileID: 1499203926}
   rotationSpeed: 350
+--- !u!1 &1514474208
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1514474209}
+  - component: {fileID: 1514474210}
+  m_Layer: 0
+  m_Name: SettingsManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1514474209
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1514474208}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1514474210
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1514474208}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 23a6a0d3872875b468e0d0a63ec24191, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1561813912
 GameObject:
   m_ObjectHideFlags: 0
@@ -5540,3 +5614,4 @@ SceneRoots:
   - {fileID: 1847521409}
   - {fileID: 341186875}
   - {fileID: 690617394}
+  - {fileID: 1514474209}

--- a/Assets/Dataskop/Scripts/Core/Data/DataManager.cs
+++ b/Assets/Dataskop/Scripts/Core/Data/DataManager.cs
@@ -377,13 +377,11 @@ namespace Dataskop.Data {
 
 		public void OnCooldownInputChanged(int newValue) {
 			int milliseconds = newValue * 1000;
-			fetchInterval = Mathf.Clamp(milliseconds, 2000, 900000);
-			PlayerPrefs.SetInt("fetchInterval", fetchInterval / 1000);
+			fetchInterval = milliseconds;
 		}
 
 		public void OnAmountInputChanged(int newValue) {
-			FetchAmount = Mathf.Clamp(newValue, 1, 2000);
-			PlayerPrefs.SetInt("fetchAmount", FetchAmount);
+			FetchAmount = newValue;
 		}
 
 	}

--- a/Assets/Dataskop/Scripts/Core/Data/DataManager.cs
+++ b/Assets/Dataskop/Scripts/Core/Data/DataManager.cs
@@ -21,8 +21,8 @@ namespace Dataskop.Data {
 		[SerializeField] private LoadingIndicator loadingIndicator;
 
 		[Header("Values")]
-		[SerializeField] private int fetchAmount = 2000;
-		[SerializeField] private int fetchInterval = 10000; // 10 Seconds
+		[SerializeField] private int fetchAmount;
+		[SerializeField] private int fetchInterval;
 
 		public readonly ApiRequestHandler RequestHandler = new();
 
@@ -62,6 +62,11 @@ namespace Dataskop.Data {
 		///     Invoked when measurement results has been updated.
 		/// </summary>
 		public event Action HasUpdatedMeasurementResults;
+
+		private void Awake() {
+			FetchAmount = PlayerPrefs.HasKey("fetchAmount") ? PlayerPrefs.GetInt("fetchAmount") : 2000;
+			fetchInterval = PlayerPrefs.HasKey("fetchInterval") ? PlayerPrefs.GetInt("fetchInterval") : 10000;
+		}
 
 		public void Initialize() {
 
@@ -373,10 +378,12 @@ namespace Dataskop.Data {
 		public void OnCooldownInputChanged(int newValue) {
 			int milliseconds = newValue * 1000;
 			fetchInterval = Mathf.Clamp(milliseconds, 2000, 900000);
+			PlayerPrefs.SetInt("fetchInterval", fetchInterval);
 		}
 
 		public void OnAmountInputChanged(int newValue) {
 			FetchAmount = Mathf.Clamp(newValue, 1, 2000);
+			PlayerPrefs.SetInt("fetchAmount", FetchAmount);
 		}
 
 	}

--- a/Assets/Dataskop/Scripts/Core/Data/DataManager.cs
+++ b/Assets/Dataskop/Scripts/Core/Data/DataManager.cs
@@ -375,13 +375,12 @@ namespace Dataskop.Data {
 			await UpdateProjectMeasurements();
 		}
 
-		public void OnCooldownInputChanged(int newValue) {
-			int milliseconds = newValue * 1000;
+		public void OnCooldownInputChanged(int milliseconds) {
 			fetchInterval = milliseconds;
 		}
 
-		public void OnAmountInputChanged(int newValue) {
-			FetchAmount = newValue;
+		public void OnAmountInputChanged(int amount) {
+			FetchAmount = amount;
 		}
 
 	}

--- a/Assets/Dataskop/Scripts/Core/Data/DataManager.cs
+++ b/Assets/Dataskop/Scripts/Core/Data/DataManager.cs
@@ -378,7 +378,7 @@ namespace Dataskop.Data {
 		public void OnCooldownInputChanged(int newValue) {
 			int milliseconds = newValue * 1000;
 			fetchInterval = Mathf.Clamp(milliseconds, 2000, 900000);
-			PlayerPrefs.SetInt("fetchInterval", fetchInterval);
+			PlayerPrefs.SetInt("fetchInterval", fetchInterval / 1000);
 		}
 
 		public void OnAmountInputChanged(int newValue) {

--- a/Assets/Dataskop/Scripts/Core/Data/SettingsManager.cs
+++ b/Assets/Dataskop/Scripts/Core/Data/SettingsManager.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Dataskop
+{
+    public class SettingsManager : MonoBehaviour {
+
+	    private const string KeyFetchAmount = "fetchAmount";
+	    private const string KeyFetchInterval = "fetchInterval";
+
+        public void OnAmountInputChanged(int newValue) {
+	        PlayerPrefs.SetInt(KeyFetchAmount, newValue);
+        }
+
+        public void OnFetchIntervalInputChanged(int newValue) {
+	        PlayerPrefs.SetInt(KeyFetchInterval, newValue * 1000);
+        }
+    }
+}

--- a/Assets/Dataskop/Scripts/Core/Data/SettingsManager.cs
+++ b/Assets/Dataskop/Scripts/Core/Data/SettingsManager.cs
@@ -1,20 +1,20 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
-namespace Dataskop
-{
-    public class SettingsManager : MonoBehaviour {
+namespace Dataskop {
 
-	    private const string KeyFetchAmount = "fetchAmount";
-	    private const string KeyFetchInterval = "fetchInterval";
+	public class SettingsManager : MonoBehaviour {
 
-        public void OnAmountInputChanged(int newValue) {
-	        PlayerPrefs.SetInt(KeyFetchAmount, newValue);
-        }
+		private const string KeyFetchAmount = "fetchAmount";
+		private const string KeyFetchInterval = "fetchInterval";
 
-        public void OnFetchIntervalInputChanged(int newValue) {
-	        PlayerPrefs.SetInt(KeyFetchInterval, newValue * 1000);
-        }
-    }
+		public void OnAmountInputChanged(int newValue) {
+			PlayerPrefs.SetInt(KeyFetchAmount, newValue);
+		}
+
+		public void OnFetchIntervalInputChanged(int newValue) {
+			PlayerPrefs.SetInt(KeyFetchInterval, newValue);
+		}
+
+	}
+
 }

--- a/Assets/Dataskop/Scripts/Core/Data/SettingsManager.cs.meta
+++ b/Assets/Dataskop/Scripts/Core/Data/SettingsManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 23a6a0d3872875b468e0d0a63ec24191
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Dataskop/Scripts/Core/UI/SettingsMenu/SettingsMenuUI.cs
+++ b/Assets/Dataskop/Scripts/Core/UI/SettingsMenu/SettingsMenuUI.cs
@@ -10,8 +10,8 @@ namespace Dataskop.UI {
 		private const string MenuOpenAnimation = "settings-menu-open";
 		private const string TogglerAnimation = "toggler-on";
 		private const string KnobAnimation = "knob-on";
-		private const string DefaultAmount = "50";
-		private const string DefaultCooldown = "60";
+		private const string DefaultAmount = "2000";
+		private const string DefaultCooldown = "10";
 		private const string ProjectSelectionTitle = "Projects";
 		private const string SettingsTitle = "Settings";
 
@@ -149,11 +149,11 @@ namespace Dataskop.UI {
 
 			AmountInput = SettingsMenuContainer.Q<TextField>("AmountInput");
 			AmountInput.RegisterCallback<ChangeEvent<string>>(OnFetchAmountInputChanged);
-			AmountInput.SetValueWithoutNotify(PlayerPrefs.HasKey("fetchAmount") ? PlayerPrefs.GetInt("fetchAmount").ToString() : "2000");
+			AmountInput.SetValueWithoutNotify(PlayerPrefs.HasKey("fetchAmount") ? PlayerPrefs.GetInt("fetchAmount").ToString() : DefaultAmount);
 
 			CooldownInput = SettingsMenuContainer.Q<TextField>("CooldownInput");
 			CooldownInput.RegisterCallback<ChangeEvent<string>>(OnFetchIntervalInputChanged);
-			CooldownInput.SetValueWithoutNotify(PlayerPrefs.HasKey("fetchInterval") ? (PlayerPrefs.GetInt("fetchInterval") / 1000).ToString() : "10");
+			CooldownInput.SetValueWithoutNotify(PlayerPrefs.HasKey("fetchInterval") ? (PlayerPrefs.GetInt("fetchInterval") / 1000).ToString() : DefaultCooldown);
 		}
 
 		private void OnDisable() {
@@ -337,7 +337,7 @@ namespace Dataskop.UI {
 			if (int.TryParse(e.newValue, out int value)) {
 				int milliseconds = value * 1000;
 				int validValue = Mathf.Clamp(milliseconds, 2000, 900000);
-				cooldownInputChanged?.Invoke(validValue / 1000);
+				cooldownInputChanged?.Invoke(validValue);
 			}
 			else {
 				CooldownInput.value = DefaultCooldown;

--- a/Assets/Dataskop/Scripts/Core/UI/SettingsMenu/SettingsMenuUI.cs
+++ b/Assets/Dataskop/Scripts/Core/UI/SettingsMenu/SettingsMenuUI.cs
@@ -153,7 +153,7 @@ namespace Dataskop.UI {
 
 			CooldownInput = SettingsMenuContainer.Q<TextField>("CooldownInput");
 			CooldownInput.RegisterCallback<ChangeEvent<string>>(OnFetchIntervalInputChanged);
-			CooldownInput.SetValueWithoutNotify(PlayerPrefs.HasKey("fetchInterval") ? PlayerPrefs.GetInt("fetchInterval").ToString() : "10000");
+			CooldownInput.SetValueWithoutNotify(PlayerPrefs.HasKey("fetchInterval") ? (PlayerPrefs.GetInt("fetchInterval") / 1000).ToString() : "10");
 		}
 
 		private void OnDisable() {
@@ -319,7 +319,8 @@ namespace Dataskop.UI {
 			}
 
 			if (int.TryParse(e.newValue, out int value)) {
-				amountInputChanged?.Invoke(value);
+				int validValue = Mathf.Clamp(value, 1, 2000);
+				amountInputChanged?.Invoke(validValue);
 			}
 			else {
 				AmountInput.value = DefaultAmount;
@@ -334,7 +335,9 @@ namespace Dataskop.UI {
 			}
 
 			if (int.TryParse(e.newValue, out int value)) {
-				cooldownInputChanged?.Invoke(value);
+				int milliseconds = value * 1000;
+				int validValue = Mathf.Clamp(milliseconds, 2000, 900000);
+				cooldownInputChanged?.Invoke(validValue / 1000);
 			}
 			else {
 				CooldownInput.value = DefaultCooldown;

--- a/Assets/Dataskop/Scripts/Core/UI/SettingsMenu/SettingsMenuUI.cs
+++ b/Assets/Dataskop/Scripts/Core/UI/SettingsMenu/SettingsMenuUI.cs
@@ -149,10 +149,11 @@ namespace Dataskop.UI {
 
 			AmountInput = SettingsMenuContainer.Q<TextField>("AmountInput");
 			AmountInput.RegisterCallback<ChangeEvent<string>>(OnFetchAmountInputChanged);
+			AmountInput.SetValueWithoutNotify(PlayerPrefs.HasKey("fetchAmount") ? PlayerPrefs.GetInt("fetchAmount").ToString() : "2000");
 
 			CooldownInput = SettingsMenuContainer.Q<TextField>("CooldownInput");
 			CooldownInput.RegisterCallback<ChangeEvent<string>>(OnFetchIntervalInputChanged);
-
+			CooldownInput.SetValueWithoutNotify(PlayerPrefs.HasKey("fetchInterval") ? PlayerPrefs.GetInt("fetchInterval").ToString() : "10000");
 		}
 
 		private void OnDisable() {


### PR DESCRIPTION
- introduce SettingsManager to Set and Save PlayerPrefs
- add FetchAmount and FetchInterval to be saved as PlayerPrefs
- Clamping of values is now in SettingsMenu UI

Please check if FetchAmount and Fetchinterval are still working correctly, in the UI it seems fine, but I don't know how to check with the actual data fetching. 😅 
Also I did a lot of *1000 or /1000 for the FetchInterval, I am not sure, if that's okay as it is.
Thanks!