### PR TITLE
183 display global time range for filter across devices when no selection is made

### DIFF
--- a/Assets/Dataskop/Scenes/World.unity
+++ b/Assets/Dataskop/Scenes/World.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44402242, g: 0.49316543, b: 0.5722324, a: 1}
+  m_IndirectSpecularColor: {r: 0.44402185, g: 0.49316472, b: 0.57223153, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -2505,8 +2505,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 416691f03deeff94fa3be1ffbca27c8e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  hourIcon: {fileID: 21300000, guid: 838c571e9e4eead44a0286449f633555, type: 3}
-  daysIcon: {fileID: 21300000, guid: 838c571e9e4eead44a0286449f633555, type: 3}
 --- !u!114 &1345926188
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2536,6 +2534,7 @@ MonoBehaviour:
         m_CallState: 2
   historyUIDocument: {fileID: 1345926184}
   cachedDataDisplay: {fileID: 1345926187}
+  dataPointsManager: {fileID: 1884349581}
 --- !u!1 &1395224430
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Dataskop/Scenes/World.unity
+++ b/Assets/Dataskop/Scenes/World.unity
@@ -2532,6 +2532,21 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+  dateFilterRequested:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 213483614}
+        m_TargetAssemblyTypeName: Dataskop.UI.DatePicker, Dataskop
+        m_MethodName: RequestConfirmation
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   historyUIDocument: {fileID: 1345926184}
   cachedDataDisplay: {fileID: 1345926187}
   dataPointsManager: {fileID: 1884349581}

--- a/Assets/Dataskop/Scripts/Core/Data/DataManager.cs
+++ b/Assets/Dataskop/Scripts/Core/Data/DataManager.cs
@@ -403,14 +403,12 @@ namespace Dataskop.Data {
 
 					}
 
-					/*
 					Debug.Log($"Result Ranges in {md.DeviceId} - {md.AttributeId} ({md.ID}):");
 					foreach (MeasurementResultRange m in md.MeasurementResults) {
 						Debug.Log(
 							$"from {m.GetTimeRange().StartTime} to {m.GetTimeRange().EndTime} with {m.Count} results");
 					}
 					Debug.Log(" ----- ");
-					*/
 
 				}
 

--- a/Assets/Dataskop/Scripts/Core/Data/DataPointsManager.cs
+++ b/Assets/Dataskop/Scripts/Core/Data/DataPointsManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Dataskop.Entities;
@@ -261,6 +262,40 @@ namespace Dataskop.Data {
 
 		public void PlaceDataPoint(Vector3 newPosition, Transform dataPointTransform) {
 			dataPointTransform.localPosition = newPosition;
+		}
+
+		public MeasurementResult GetLatestResult() {
+
+			MeasurementResult latestResult = null;
+			DateTime latestDate = new(1900, 1, 1);
+
+			foreach (var dp in DataPoints) {
+				foreach (var md in dp.Device.MeasurementDefinitions) {
+					if (md.LatestMeasurementResult.Timestamp > latestDate) {
+						latestDate = md.LatestMeasurementResult.Timestamp;
+						latestResult = md.LatestMeasurementResult;
+					}
+				}
+			}
+
+			return latestResult;
+		}
+
+		public MeasurementResult GetEarliestResult() {
+
+			MeasurementResult earliestResult = null;
+			DateTime earliestDate = DateTime.Now;
+
+			foreach (var dp in DataPoints) {
+				foreach (var md in dp.Device.MeasurementDefinitions) {
+					if (md.LatestMeasurementResult.Timestamp < earliestDate) {
+						earliestDate = md.FirstMeasurementResult.Timestamp;
+						earliestResult = md.FirstMeasurementResult;
+					}
+				}
+			}
+
+			return earliestResult;
 		}
 
 		private void ClearDataPoints() {

--- a/Assets/Dataskop/Scripts/Core/UI/HistoryMenu/HistoryControllerUI.cs
+++ b/Assets/Dataskop/Scripts/Core/UI/HistoryMenu/HistoryControllerUI.cs
@@ -12,6 +12,7 @@ namespace Dataskop.UI {
 	public class HistoryControllerUI : MonoBehaviour {
 
 		public UnityEvent<int, int> historySliderValueChanged;
+		public UnityEvent<TimeRange> dateFilterRequested;
 
 		[SerializeField] private UIDocument historyUIDocument;
 		[SerializeField] private CachedDataDisplayUI cachedDataDisplay;
@@ -36,6 +37,7 @@ namespace Dataskop.UI {
 			historySlider = new HistorySliderUI(historyUIDocument.rootVisualElement.Q<VisualElement>("HistoryContainer"));
 			cachedDataDisplay.Init(historyUIDocument.rootVisualElement.Q<VisualElement>("CachedDataDisplay"));
 			historySlider.SliderValueChanged += OnHistorySliderMoved;
+			cachedDataDisplay.OnFilterRequested += OnFilterRequestSent;
 		}
 
 		public void OnHistoryButtonPressed() {
@@ -161,6 +163,10 @@ namespace Dataskop.UI {
 
 			UpdateCachedDataDisplay();
 
+		}
+
+		private void OnFilterRequestSent(TimeRange filter) {
+			dateFilterRequested?.Invoke(filter);
 		}
 
 		private void UpdateCachedDataDisplay() {

--- a/Assets/Dataskop/Scripts/Core/UI/HistoryMenu/HistoryControllerUI.cs
+++ b/Assets/Dataskop/Scripts/Core/UI/HistoryMenu/HistoryControllerUI.cs
@@ -13,6 +13,7 @@ namespace Dataskop.UI {
 
 		[SerializeField] private UIDocument historyUIDocument;
 		[SerializeField] private CachedDataDisplayUI cachedDataDisplay;
+		[SerializeField] private DataPointsManager dataPointsManager;
 
 		private HistorySliderUI historySlider;
 
@@ -97,6 +98,12 @@ namespace Dataskop.UI {
 
 			if (!IsActive) return;
 
+			if (newAttribute.ID == "all") {
+				IsActive = false;
+				HideHistory();
+				return;
+			}
+
 			historySlider.ClearData();
 			cachedDataDisplay.ClearData();
 		}
@@ -111,6 +118,11 @@ namespace Dataskop.UI {
 			SelectedDataPoint = selectedDataPoint;
 
 			if (SelectedDataPoint == null) {
+
+				//TODO: Get somehow the data of all the MDs and display that.
+				
+				
+				
 				historySlider.ClearData();
 				cachedDataDisplay.ClearData();
 				return;

--- a/Assets/Dataskop/Scripts/Core/UI/HistoryMenu/HistoryControllerUI.cs
+++ b/Assets/Dataskop/Scripts/Core/UI/HistoryMenu/HistoryControllerUI.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Linq;
 using Dataskop.Data;
 using Dataskop.Entities;
 using UnityEngine;
@@ -26,7 +27,7 @@ namespace Dataskop.UI {
 			historySlider.Hide();
 			cachedDataDisplay.Hide();
 			historySlider.ClearData();
-			cachedDataDisplay.ClearData();
+			historySlider.ClearData();
 			historyUIDocument.rootVisualElement.visible = false;
 		}
 
@@ -47,9 +48,21 @@ namespace Dataskop.UI {
 		}
 
 		public void ShowHistory() {
+
+			if (SelectedDataPoint == null) {
+				MeasurementResult earliest = dataPointsManager.GetEarliestResult();
+				MeasurementResult latest = dataPointsManager.GetLatestResult();
+				cachedDataDisplay.SetGlobalTimeLabels(earliest.Timestamp.ToShortDateString(), latest.Timestamp.ToShortDateString());
+				cachedDataDisplay.SetFilterLabelTexts(earliest.Timestamp.ToShortDateString(), latest.Timestamp.ToShortDateString());
+				cachedDataDisplay.UpdateMinMaxSlider(latest.Timestamp, earliest.Timestamp);
+				cachedDataDisplay.SetLabelPositionsForRange(earliest.Timestamp, latest.Timestamp, latest.Timestamp, earliest.Timestamp);
+				cachedDataDisplay.ClearCacheDisplay();
+			}
+
 			historySlider.Show();
 			cachedDataDisplay.Show();
 			IsActive = true;
+
 		}
 
 		public void HideHistory() {
@@ -70,6 +83,13 @@ namespace Dataskop.UI {
 				historySlider.UpdateTimeLabel(SelectedDataPoint.FocusedMeasurement.GetDateText());
 			}
 			else {
+				MeasurementResult earliest = dataPointsManager.GetEarliestResult();
+				MeasurementResult latest = dataPointsManager.GetLatestResult();
+				cachedDataDisplay.SetGlobalTimeLabels(earliest.Timestamp.ToShortDateString(), latest.Timestamp.ToShortDateString());
+				cachedDataDisplay.SetFilterLabelTexts(earliest.Timestamp.ToShortDateString(), latest.Timestamp.ToShortDateString());
+				cachedDataDisplay.UpdateMinMaxSlider(latest.Timestamp, earliest.Timestamp);
+				cachedDataDisplay.SetLabelPositionsForRange(earliest.Timestamp, latest.Timestamp, latest.Timestamp, earliest.Timestamp);
+				cachedDataDisplay.ClearCacheDisplay();
 				cachedDataDisplay.ClearData();
 				historySlider.ClearData();
 			}
@@ -118,8 +138,14 @@ namespace Dataskop.UI {
 			SelectedDataPoint = selectedDataPoint;
 
 			if (SelectedDataPoint == null) {
+				MeasurementResult earliest = dataPointsManager.GetEarliestResult();
+				MeasurementResult latest = dataPointsManager.GetLatestResult();
+				cachedDataDisplay.SetGlobalTimeLabels(earliest.Timestamp.ToShortDateString(), latest.Timestamp.ToShortDateString());
+				cachedDataDisplay.SetFilterLabelTexts(earliest.Timestamp.ToShortDateString(), latest.Timestamp.ToShortDateString());
+				cachedDataDisplay.UpdateMinMaxSlider(latest.Timestamp, earliest.Timestamp);
+				cachedDataDisplay.SetLabelPositionsForRange(earliest.Timestamp, latest.Timestamp, latest.Timestamp, earliest.Timestamp);
+				cachedDataDisplay.ClearCacheDisplay();
 				historySlider.ClearData();
-				cachedDataDisplay.ClearData();
 				return;
 			}
 
@@ -154,7 +180,7 @@ namespace Dataskop.UI {
 
 			cachedDataDisplay.SetGlobalTimeLabels(
 				SelectedDataPoint.MeasurementDefinition.FirstMeasurementResult.GetShortDateText(),
-				SelectedDataPoint.MeasurementDefinition.LatestMeasurementResult.GetShortDateText()
+				SelectedDataPoint.MeasurementDefinition.MeasurementResults.First().GetTimeRange().EndTime.ToShortDateString()
 			);
 
 			cachedDataDisplay.ClearCacheDisplay();

--- a/Assets/Dataskop/Scripts/Core/UI/SettingsMenu/DatePicker.cs
+++ b/Assets/Dataskop/Scripts/Core/UI/SettingsMenu/DatePicker.cs
@@ -92,7 +92,7 @@ namespace Dataskop.UI {
 
 		}
 
-		private void RequestConfirmation(TimeRange range) {
+		public void RequestConfirmation(TimeRange range) {
 			dialogWindow.style.display = new StyleEnum<DisplayStyle>(DisplayStyle.Flex);
 			proceedButton.RegisterCallback<ClickEvent, TimeRange>(OnConfirm, range);
 			cancelButton.RegisterCallback<ClickEvent>(OnCancel);


### PR DESCRIPTION
## Changelog

- Added global time in display when no selection is made
- Added dynamic time labels for min/max slider
- Added filter functionality to cached data display

# Known Issues
- Previous dates still get shown during loading times
- Label dates at the far end of the slider do not match actual date